### PR TITLE
Strip BBCode tags from FurAffinity descriptions

### DIFF
--- a/src/furaffinity/bbcode.ts
+++ b/src/furaffinity/bbcode.ts
@@ -1,0 +1,37 @@
+// FurAffinity descriptions can leak raw BBCode markup into the og:description
+// meta tag. We clean it up in two passes so embeds read as plain prose:
+//   1. Remove any matched [tag]...[/tag] pair, keeping its inner text. This
+//      catches every real tag without maintaining an exhaustive list, and
+//      leaves unpaired brackets FA artists use in prose (e.g. "[YCH]", "[WIP]",
+//      "[Commissions OPEN]") untouched.
+//   2. Remove leftover stray/malformed known tags (an opening or closing tag
+//      with no partner). Scoped to known tags so we don't eat unknown prose
+//      brackets that survived pass 1.
+const KNOWN_TAGS = [
+  'b',
+  'i',
+  'u',
+  's',
+  'sub',
+  'sup',
+  'left',
+  'center',
+  'right',
+  'quote',
+  'url',
+  'color',
+  'spoiler',
+  'yt',
+];
+
+const BBCODE_PAIR_PATTERN = /\[([a-z0-9]+)(?:=[^\]]*)?\]([\s\S]*?)\[\/\1\]/gi;
+const KNOWN_TAG_PATTERN = new RegExp(`\\[/?(?:${KNOWN_TAGS.join('|')})(?:=[^\\]]*)?\\]`, 'gi');
+
+function stripPairs(text: string): string {
+  const stripped = text.replace(BBCODE_PAIR_PATTERN, '$2');
+  return stripped === text ? text : stripPairs(stripped);
+}
+
+export function stripBbcode(text: string): string {
+  return stripPairs(text).replace(KNOWN_TAG_PATTERN, '').trim();
+}

--- a/src/furaffinity/submission.ts
+++ b/src/furaffinity/submission.ts
@@ -1,4 +1,5 @@
 import * as cheerio from 'cheerio';
+import { stripBbcode } from './bbcode.js';
 import type { SubmissionInfo } from './submissionInfo.js';
 
 type SubmissionPageInfo = Omit<SubmissionInfo, 'sizeBytes' | 'contentType'>;
@@ -63,7 +64,7 @@ export function parseSubmissionPage(html: string): SubmissionPageResult {
 
   const url = $('meta[property*="og:url"]').attr('content');
   const title = $('meta[property*="og:title"]').attr('content');
-  const description = $('meta[property*="og:description"]').attr('content');
+  const rawDescription = $('meta[property*="og:description"]').attr('content');
   const viewCountText =
     $('.submission-page-stats div[title="Views"] div').first().text().trim() || $('div.views span').first().text(); // fallback old layout
   const commentCountText =
@@ -78,11 +79,13 @@ export function parseSubmissionPage(html: string): SubmissionPageResult {
   const artistName = artistLink.text().trim();
   const artistHref = artistLink.attr('href');
 
-  if (!url || !title || description === undefined || !thumbnailSrc || !artistName || !artistHref) {
+  if (!url || !title || rawDescription === undefined || !thumbnailSrc || !artistName || !artistHref) {
     throw new Error(
-      `Failed to parse submission page: missing fields (url=${url}, title=${title}, description=${description}, thumbnail=${thumbnailSrc}, artist=${artistName})`,
+      `Failed to parse submission page: missing fields (url=${url}, title=${title}, description=${rawDescription}, thumbnail=${thumbnailSrc}, artist=${artistName})`,
     );
   }
+
+  const description = stripBbcode(rawDescription);
 
   const viewCount = parseInt(viewCountText, 10);
   const commentCount = parseInt(commentCountText, 10);

--- a/tests/bbcode.test.ts
+++ b/tests/bbcode.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { stripBbcode } from '../src/furaffinity/bbcode.js';
+
+describe('stripBbcode', () => {
+  it('removes simple formatting tags but keeps inner text', () => {
+    expect(stripBbcode('[b]Hello[/b] [i]world[/i]')).toBe('Hello world');
+  });
+
+  it('removes tags with attributes', () => {
+    expect(stripBbcode('[color=red]red[/color] [url=https://furaffinity.net]link[/url]')).toBe('red link');
+  });
+
+  it('is case-insensitive', () => {
+    expect(stripBbcode('[B]bold[/B] [Quote=Someone]hi[/QUOTE]')).toBe('bold hi');
+  });
+
+  it('strips alignment, spoiler, and nested tags', () => {
+    expect(stripBbcode('[center][b][spoiler]secret[/spoiler][/b][/center]')).toBe('secret');
+  });
+
+  it('leaves unpaired brackets (FA prose like [YCH]/[WIP]) untouched', () => {
+    expect(stripBbcode('[WIP] commission [b]open[/b]')).toBe('[WIP] commission open');
+    expect(stripBbcode('[Commissions OPEN] check my [i]page[/i]')).toBe('[Commissions OPEN] check my page');
+  });
+
+  it('strips a stray/malformed known tag (opening or closing only)', () => {
+    expect(stripBbcode('[b]bold with no close')).toBe('bold with no close');
+    expect(stripBbcode('text with dangling close[/i]')).toBe('text with dangling close');
+    expect(stripBbcode('[color=red]red with no close')).toBe('red with no close');
+  });
+
+  it('leaves a stray unknown bracket in place', () => {
+    expect(stripBbcode('[YCH] slots open')).toBe('[YCH] slots open');
+    expect(stripBbcode('[unknown]no close here')).toBe('[unknown]no close here');
+  });
+
+  it('unwraps properly nested pairs', () => {
+    expect(stripBbcode('[b][i]text[/i][/b]')).toBe('text');
+    expect(stripBbcode('[quote=Someone][b]nested[/b] quote[/quote]')).toBe('nested quote');
+    expect(stripBbcode('[b]x[b]y[/b]z[/b]')).toBe('xyz');
+  });
+
+  it('unwraps improperly nested pairs', () => {
+    expect(stripBbcode('[b][i]text[/b][/i]')).toBe('text');
+  });
+
+  it('trims surrounding whitespace left by stripped tags', () => {
+    expect(stripBbcode('[center]centered[/center]')).toBe('centered');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(stripBbcode('')).toBe('');
+  });
+
+  it('leaves plain text without BBCode unchanged', () => {
+    expect(stripBbcode('Just a normal description.')).toBe('Just a normal description.');
+  });
+
+  it('strips a real FA description with nested [left]/[b]/[color=#hex] and emoji', () => {
+    const input =
+      '[left][b][color=#bcc7d7]  A real scorcher of a day 🌞 🌿 [/color][/b][/left]\n' +
+      '[left][i][color=#9fadc1]  Personal art  [/color][/i][/left]';
+    // Interior whitespace is preserved on purpose: it may be intentional spacing
+    // an artist placed inside the tags rather than around them.
+    expect(stripBbcode(input)).toBe('A real scorcher of a day 🌞 🌿 \n  Personal art');
+  });
+});

--- a/tests/fixtures/image-bbcode-desc.html
+++ b/tests/fixtures/image-bbcode-desc.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <meta property="og:url" content="https://www.furaffinity.net/view/141/" />
+  <meta property="og:title" content="Test Image BBCode Desc" />
+  <meta property="og:description" content="[b]Bold[/b] and [color=red]red[/color] [url=https://furaffinity.net]text[/url]" />
+</head>
+<body>
+  <img id="submissionImg" data-preview-src="//t.furaffinity.net/141@400-thumb.jpg" />
+  <div class="submission-id-sub-container">
+    <a href="/user/testartist/">TestArtist</a>
+  </div>
+  <div class="views"><span>1234</span></div>
+  <section class="stats-container"><div class="comments"><span>56</span></div></section>
+  <div class="favorites"><span>789</span></div>
+  <script data-content-type="image"></script>
+  <div class="download"><a href="//d.furaffinity.net/art/testartist/141/test.jpg">Download</a></div>
+</body>
+</html>

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -30,6 +30,7 @@ const imageNoContentLengthHtml = fixture('image-no-content-length.html');
 const accountDisabledHtml = fixture('account-disabled.html');
 const blockedHtml = fixture('blocked.html');
 const offlineHtml = fixture('offline.html');
+const imageBbcodeDescHtml = fixture('image-bbcode-desc.html');
 
 const DISCORD_UA = 'Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)';
 const TELEGRAM_UA = 'TelegramBot (like TwitterBot)';
@@ -55,6 +56,7 @@ const defaultHandlers = [
   http.get('https://www.furaffinity.net/view/139', () => HttpResponse.text(accountDisabledHtml)),
   http.get('https://www.furaffinity.net/view/131', () => HttpResponse.text(blockedHtml)),
   http.get('https://www.furaffinity.net/view/140', () => HttpResponse.text(offlineHtml)),
+  http.get('https://www.furaffinity.net/view/141', () => HttpResponse.text(imageBbcodeDescHtml)),
   http.get('https://www.furaffinity.net/view/132', () => new HttpResponse(null, { status: 500 })),
 
   // Asset HEAD requests for images
@@ -80,6 +82,10 @@ const defaultHandlers = [
   ),
   http.head(
     'https://d.furaffinity.net/art/testartist/138/test.jpg',
+    () => new HttpResponse(null, { headers: { 'content-length': '1048576', 'content-type': 'image/jpeg' } }),
+  ),
+  http.head(
+    'https://d.furaffinity.net/art/testartist/141/test.jpg',
     () => new HttpResponse(null, { headers: { 'content-length': '1048576', 'content-type': 'image/jpeg' } }),
   ),
 
@@ -226,6 +232,16 @@ describe('image embeds', () => {
     expect(response.statusCode).toBe(200);
     expect(response.body).toContain('Test Image Empty Desc');
     expect(response.body).toContain('og:image');
+  });
+
+  it('strips BBCode tags from the description', async () => {
+    const response = await app.inject({ method: 'GET', url: '/view/141', headers: { 'user-agent': DISCORD_UA } });
+    expect(response.statusCode).toBe(200);
+    const body = response.body;
+    expect(body).toContain('Bold and red text');
+    expect(body).not.toContain('[b]');
+    expect(body).not.toContain('[color=red]');
+    expect(body).not.toContain('[url=');
   });
 });
 


### PR DESCRIPTION
Fixes #25.

FurAffinity leaks raw BBCode markup into the `og:description` meta tag, so link previews render tags literally (e.g. `[left][b][color=#bcc7d7]  A real scorcher of a day 🌞 🌿 [/color][/b][/left]`).

## Approach

`stripBbcode` cleans descriptions in two passes:

1. **Unwrap any matched `[tag]...[/tag]` pair**, keeping the inner text. Applied to a fixed point so nested tags collapse (proper and improper nesting). This catches every real tag without maintaining an exhaustive list.
2. **Remove leftover stray/malformed known tags** — an opening- or closing-only tag with no partner. Scoped to the known FA tag set so unknown unpaired brackets artists use in prose (`[YCH]`, `[WIP]`, `[Commissions OPEN]`) are left untouched.

Applied to the parsed `og:description` in `submission.ts`. Interior whitespace is preserved on purpose — it may be intentional spacing an artist placed inside the tags rather than around them.

## Tests

- Unit tests in `tests/bbcode.test.ts` covering pairs, attributes, case-insensitivity, proper/improper nesting, stray known tags, unknown-bracket preservation, and a real leaked FA description with nested `[left]/[b]/[color=#hex]` + emoji.
- Integration test + fixture verifying the rendered embed strips BBCode end-to-end.