### PR TITLE
Add Telegram Instant View support

### DIFF
--- a/src/embedGenerator/imageEmbed.ts
+++ b/src/embedGenerator/imageEmbed.ts
@@ -1,4 +1,5 @@
 import type { SubmissionInfo } from '../furaffinity/submissionInfo.js';
+import { renderImageInstantViewBody } from './instantView.js';
 import { OpenGraphBuilder } from './openGraphBuilder.js';
 
 const FIVE_MB = 1024 * 1024 * 5;
@@ -52,6 +53,8 @@ export function generateImageTelegramEmbed(info: SubmissionInfo): string {
       builder.withImageDimensions(info.width, info.height);
     }
   }
+
+  builder.withBody(renderImageInstantViewBody(info));
 
   return builder.build();
 }

--- a/src/embedGenerator/instantView.ts
+++ b/src/embedGenerator/instantView.ts
@@ -1,0 +1,56 @@
+import type { MusicInfo, StoryInfo, SubmissionInfo } from '../furaffinity/submissionInfo.js';
+import { escapeHtml } from '../html.js';
+
+const fmt = (n: number) => new Intl.NumberFormat('en-US').format(n);
+
+// Telegram Instant View templates extract content by XPath against this markup,
+// so the structure (article > h1 > byline > media > body > stats footer) must stay stable.
+
+type ArticleMeta = {
+  title: string;
+  artistName: string;
+  artistUrl: string;
+  descriptionHtml: string;
+  viewCount: number;
+  commentCount: number;
+  faveCount: number;
+};
+
+function renderArticle(meta: ArticleMeta, mediaBlock: string, extraBlock = ''): string {
+  const parts = [
+    `<h1>${escapeHtml(meta.title)}</h1>`,
+    `<address>by <a rel="author" href="${escapeHtml(meta.artistUrl)}">${escapeHtml(meta.artistName)}</a></address>`,
+    mediaBlock,
+    extraBlock,
+    meta.descriptionHtml ? `<section class="description">${meta.descriptionHtml}</section>` : '',
+    `<footer>👁 ${fmt(meta.viewCount)} · 💬 ${fmt(meta.commentCount)} · ⭐ ${fmt(meta.faveCount)}</footer>`,
+  ].filter(Boolean);
+
+  return `<article>\n  ${parts.join('\n  ')}\n</article>`;
+}
+
+export function renderImageInstantViewBody(info: SubmissionInfo): string {
+  // IV re-fetches media server-side and has no 5MB card limit, so always use the full-resolution URL.
+  const media =
+    info.contentType === 'video/mp4'
+      ? `<video src="${escapeHtml(info.imageUrl)}" controls="controls"></video>`
+      : `<img src="${escapeHtml(info.imageUrl)}" alt="${escapeHtml(info.title)}" />`;
+
+  return renderArticle(info, `<figure>${media}</figure>`);
+}
+
+export function renderStoryInstantViewBody(info: StoryInfo): string {
+  const figure = `<figure><img src="${escapeHtml(info.thumbnailUrl)}" alt="${escapeHtml(info.title)}" /></figure>`;
+  const excerpt = info.excerpt
+    ? `<blockquote>${escapeHtml(info.excerpt).replace(/\r?\n/g, '<br />')}</blockquote>`
+    : '';
+
+  return renderArticle(info, figure, excerpt);
+}
+
+export function renderMusicInstantViewBody(info: MusicInfo): string {
+  const figure = `<figure><img src="${escapeHtml(info.thumbnailUrl)}" alt="${escapeHtml(info.title)}" /></figure>`;
+  const audio = `<audio src="${escapeHtml(info.audioUrl)}" controls="controls"></audio>`;
+
+  return renderArticle(info, figure, audio);
+}

--- a/src/embedGenerator/musicEmbed.ts
+++ b/src/embedGenerator/musicEmbed.ts
@@ -1,4 +1,5 @@
 import type { MusicInfo } from '../furaffinity/submissionInfo.js';
+import { renderMusicInstantViewBody } from './instantView.js';
 import { OpenGraphBuilder } from './openGraphBuilder.js';
 
 const fmt = (n: number) => new Intl.NumberFormat('en-US').format(n);
@@ -27,12 +28,15 @@ export function generateMusicTelegramEmbed(info: MusicInfo): string {
   const stats = `👁 ${fmt(info.viewCount)}  💬 ${fmt(info.commentCount)}  ⭐ ${fmt(info.faveCount)}`;
   const fullDescription = info.description ? `${stats}\n\n${info.description}` : stats;
 
-  return new OpenGraphBuilder()
+  const builder = new OpenGraphBuilder()
     .withDefaultMetadata()
     .withTwitterCard('summary_large_image')
     .withTitle(info.title)
     .withDescription(fullDescription)
     .withUrl(info.url)
-    .withImage(info.thumbnailUrl, 'image/jpeg')
-    .build();
+    .withImage(info.thumbnailUrl, 'image/jpeg');
+
+  builder.withBody(renderMusicInstantViewBody(info));
+
+  return builder.build();
 }

--- a/src/embedGenerator/openGraphBuilder.ts
+++ b/src/embedGenerator/openGraphBuilder.ts
@@ -1,9 +1,8 @@
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
+import { escapeHtml } from '../html.js';
 
 export class OpenGraphBuilder {
   private tags: string[] = [];
+  private bodyHtml: string | null = null;
 
   withDefaultMetadata(ogType: string = 'website'): this {
     this.tags.push(`
@@ -89,13 +88,20 @@ export class OpenGraphBuilder {
     return this;
   }
 
+  // Renders a real <body> for Telegram Instant View templates to extract from.
+  withBody(html: string): this {
+    this.bodyHtml = html;
+    return this;
+  }
+
   build(): string {
     const meta = this.tags.join('\n');
+    const body = this.bodyHtml ? `\n<body>\n${this.bodyHtml}\n</body>` : '';
     return `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html lang="en" class="no-js" xmlns="http://www.w3.org/1999/xhtml">
 <head>
 ${meta}
-</head>
+</head>${body}
 </html>`;
   }
 }

--- a/src/embedGenerator/storyEmbed.ts
+++ b/src/embedGenerator/storyEmbed.ts
@@ -1,4 +1,5 @@
 import type { StoryInfo } from '../furaffinity/submissionInfo.js';
+import { renderStoryInstantViewBody } from './instantView.js';
 import { OpenGraphBuilder } from './openGraphBuilder.js';
 
 const fmt = (n: number) => new Intl.NumberFormat('en-US').format(n);
@@ -20,6 +21,24 @@ export function generateStoryEmbed(info: StoryInfo, oEmbedUrl?: string): string 
   if (oEmbedUrl) {
     builder.withOEmbed(oEmbedUrl);
   }
+
+  return builder.build();
+}
+
+export function generateStoryTelegramEmbed(info: StoryInfo): string {
+  const stats = `👁 ${fmt(info.viewCount)}  💬 ${fmt(info.commentCount)}  ⭐ ${fmt(info.faveCount)}`;
+  const contentSection = info.excerpt ?? (info.description || null);
+  const fullDescription = contentSection ? `${stats}\n\n${contentSection}` : stats;
+
+  const builder = new OpenGraphBuilder()
+    .withDefaultMetadata()
+    .withTwitterCard('summary_large_image')
+    .withTitle(info.title)
+    .withDescription(fullDescription)
+    .withUrl(info.url)
+    .withImage(info.thumbnailUrl, 'image/jpeg');
+
+  builder.withBody(renderStoryInstantViewBody(info));
 
   return builder.build();
 }

--- a/src/furaffinity/description.ts
+++ b/src/furaffinity/description.ts
@@ -1,0 +1,65 @@
+import * as cheerio from 'cheerio';
+import { escapeHtml } from '../html.js';
+
+const FA_BASE = 'https://www.furaffinity.net';
+const ALLOWED_TAGS = new Set(['a', 'b', 'strong', 'i', 'em', 'u', 'br']);
+
+// FA submission descriptions are rich HTML (user-icon links, bbcode spans, colours, avatars).
+// Reduce them to a small, safe subset suitable for a Telegram Instant View article body.
+export function cleanDescriptionHtml(rawInnerHtml: string): string {
+  const $ = cheerio.load(rawInnerHtml, null, false);
+
+  // User-icon links carry only an avatar image; turn them into @username text links.
+  $('a.iconusername').each((_, el) => {
+    const user = ($(el).attr('href') ?? '').replace(/^\/user\//, '').replace(/\/$/, '');
+    $(el).replaceWith(user ? `<a href="${FA_BASE}/user/${escapeHtml(user)}">@${escapeHtml(user)}</a>` : '');
+  });
+
+  $('img').remove();
+
+  // Normalise links: resolve to absolute URLs, unwrap FA's external redirector, drop other attributes.
+  $('a').each((_, el) => {
+    const resolved = resolveHref($(el).attr('href'));
+    if (!resolved) {
+      $(el).replaceWith($(el).contents());
+      return;
+    }
+    el.attribs = { href: resolved };
+  });
+
+  // Unwrap anything outside the allowlist, keeping its children; strip attributes from what remains.
+  $('*').each((_, node) => {
+    if (!('tagName' in node)) return;
+    if (!ALLOWED_TAGS.has(node.tagName)) {
+      $(node).replaceWith($(node).contents());
+    } else if (node.tagName !== 'a') {
+      node.attribs = {};
+    }
+  });
+
+  return collapseWhitespace($.root().html() ?? '');
+}
+
+export function plainToHtml(text: string): string {
+  return escapeHtml(text).replace(/\r?\n/g, '<br />');
+}
+
+function resolveHref(href: string | undefined): string | null {
+  const trimmed = href?.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes('/externalurl/?q=')) {
+    const q = new URL(trimmed, FA_BASE).searchParams.get('q');
+    if (q) return q;
+  }
+  if (trimmed.startsWith('//')) return `https:${trimmed}`;
+  if (trimmed.startsWith('/')) return `${FA_BASE}${trimmed}`;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return null;
+}
+
+function collapseWhitespace(html: string): string {
+  return html
+    .replace(/\s+/g, ' ')
+    .replace(/\s*(<br\s*\/?>)\s*/g, '$1')
+    .trim();
+}

--- a/src/furaffinity/submission.ts
+++ b/src/furaffinity/submission.ts
@@ -1,5 +1,6 @@
 import * as cheerio from 'cheerio';
 import { stripBbcode } from './bbcode.js';
+import { cleanDescriptionHtml, plainToHtml } from './description.js';
 import type { SubmissionInfo } from './submissionInfo.js';
 
 type SubmissionPageInfo = Omit<SubmissionInfo, 'sizeBytes' | 'contentType' | 'width' | 'height'>;
@@ -86,6 +87,10 @@ export function parseSubmissionPage(html: string): SubmissionPageResult {
   }
 
   const description = stripBbcode(rawDescription);
+  const descriptionTextEl = $('.submission-description-text').first();
+  const descriptionHtml = descriptionTextEl.length
+    ? cleanDescriptionHtml(descriptionTextEl.html() ?? '')
+    : plainToHtml(description);
 
   const viewCount = parseInt(viewCountText, 10);
   const commentCount = parseInt(commentCountText, 10);
@@ -101,6 +106,7 @@ export function parseSubmissionPage(html: string): SubmissionPageResult {
     url,
     title,
     description,
+    descriptionHtml,
     viewCount,
     commentCount,
     faveCount,

--- a/src/furaffinity/submissionInfo.ts
+++ b/src/furaffinity/submissionInfo.ts
@@ -6,6 +6,7 @@ export type SubmissionInfo = {
   url: string;
   title: string;
   description: string;
+  descriptionHtml: string;
   viewCount: number;
   commentCount: number;
   faveCount: number;
@@ -23,6 +24,7 @@ export type StoryInfo = {
   url: string;
   title: string;
   description: string;
+  descriptionHtml: string;
   viewCount: number;
   commentCount: number;
   faveCount: number;
@@ -36,6 +38,7 @@ export type MusicInfo = {
   url: string;
   title: string;
   description: string;
+  descriptionHtml: string;
   viewCount: number;
   commentCount: number;
   faveCount: number;

--- a/src/html.ts
+++ b/src/html.ts
@@ -1,0 +1,3 @@
+export function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}

--- a/src/submissionHandler.ts
+++ b/src/submissionHandler.ts
@@ -3,7 +3,7 @@ import type { Config } from './config.js';
 import { generateImageEmbed, generateImageTelegramEmbed } from './embedGenerator/imageEmbed.js';
 import { generateMessageEmbed } from './embedGenerator/messageEmbed.js';
 import { generateMusicEmbed, generateMusicTelegramEmbed } from './embedGenerator/musicEmbed.js';
-import { generateStoryEmbed } from './embedGenerator/storyEmbed.js';
+import { generateStoryEmbed, generateStoryTelegramEmbed } from './embedGenerator/storyEmbed.js';
 import { fetchSubmissionInfo } from './furaffinity/client.js';
 import type { ServerErrorDetail } from './furaffinity/submissionInfo.js';
 import { noticeError } from './metrics.js';
@@ -50,7 +50,11 @@ export async function handleSubmission(id: number, userAgent: string, config: Co
       }
       case 'story': {
         const oEmbedUrl = config.publicUrl ? `${config.publicUrl}/oembed?id=${id}` : undefined;
-        return { type: 'embed', html: generateStoryEmbed(result.info, oEmbedUrl), meta };
+        const html =
+          requester === 'telegram'
+            ? generateStoryTelegramEmbed(result.info)
+            : generateStoryEmbed(result.info, oEmbedUrl);
+        return { type: 'embed', html, meta };
       }
       case 'music': {
         const oEmbedUrl = config.publicUrl ? `${config.publicUrl}/oembed?id=${id}` : undefined;

--- a/tests/fixtures/image-rich-desc.html
+++ b/tests/fixtures/image-rich-desc.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+  <meta property="og:url" content="https://www.furaffinity.net/view/142/" />
+  <meta property="og:title" content="Test Image Rich Desc" />
+  <meta property="og:description" content="A truncated snippet…" />
+</head>
+<body>
+  <img id="submissionImg" data-preview-src="//t.furaffinity.net/142@400-thumb.jpg" />
+  <div class="submission-description">
+    <div class="submission-description-artist">
+      <a href="/user/testartist/"><img class="submission-user-icon avatar" src="//a.furaffinity.net/x/testartist.gif" /></a>
+      <span class="c-usernameBlockSimple"><a href="/user/testartist/">TestArtist</a></span>
+    </div>
+    <div class="submission-description-text user-submitted-links">
+      Full description with a
+      <a href="/user/friend" class="iconusername"><img src="//a.furaffinity.net/x/friend.gif" title="friend" alt="friend" /></a>
+      mention and a
+      <a class="auto_link external" href="https://www.furaffinity.net/externalurl/?q=https%3A%2F%2Fexample.com%2Fart">
+        <b class="bbcode bbcode_b"><span class="bbcode" style="color:#FFABC7;">link</span></b>
+      </a>.<br />
+      <span class="bbcode" style="color:red;">Second line kept.</span>
+    </div>
+  </div>
+  <div class="views"><span>1234</span></div>
+  <section class="stats-container"><div class="comments"><span>56</span></div></section>
+  <div class="favorites"><span>789</span></div>
+  <script data-content-type="image"></script>
+  <div class="download"><a href="//d.furaffinity.net/art/testartist/142/test.jpg">Download</a></div>
+</body>
+</html>

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -31,6 +31,7 @@ const accountDisabledHtml = fixture('account-disabled.html');
 const blockedHtml = fixture('blocked.html');
 const offlineHtml = fixture('offline.html');
 const imageBbcodeDescHtml = fixture('image-bbcode-desc.html');
+const imageRichDescHtml = fixture('image-rich-desc.html');
 
 const DISCORD_UA = 'Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)';
 const TELEGRAM_UA = 'TelegramBot (like TwitterBot)';
@@ -82,6 +83,7 @@ const defaultHandlers = [
   http.get('https://www.furaffinity.net/view/131', () => HttpResponse.text(blockedHtml)),
   http.get('https://www.furaffinity.net/view/140', () => HttpResponse.text(offlineHtml)),
   http.get('https://www.furaffinity.net/view/141', () => HttpResponse.text(imageBbcodeDescHtml)),
+  http.get('https://www.furaffinity.net/view/142', () => HttpResponse.text(imageRichDescHtml)),
   http.get('https://www.furaffinity.net/view/132', () => new HttpResponse(null, { status: 500 })),
 
   // Asset requests for images (ranged GET for size + dimensions)
@@ -105,6 +107,10 @@ const defaultHandlers = [
   ),
   http.get('https://d.furaffinity.net/art/testartist/141/test.jpg', () =>
     imageResponse('image/jpeg', 1048576, jpegHeader(1200, 800)),
+  ),
+  http.head(
+    'https://d.furaffinity.net/art/testartist/142/test.jpg',
+    () => new HttpResponse(null, { headers: { 'content-length': '1048576', 'content-type': 'image/jpeg' } }),
   ),
 
   // Story text fetch
@@ -282,16 +288,16 @@ describe('telegram image embeds', () => {
     const response = await app.inject({ method: 'GET', url: '/view/125', headers: { 'user-agent': TELEGRAM_UA } });
     expect(response.statusCode).toBe(200);
     const body = response.body;
-    expect(body).toContain('t.furaffinity.net/125@400-thumb.jpg');
-    expect(body).not.toContain('d.furaffinity.net/art/testartist/125/large.jpg');
+    expect(body).toContain('og:image" content="https://t.furaffinity.net/125@400-thumb.jpg"');
+    expect(body).not.toContain('og:image" content="https://d.furaffinity.net/art/testartist/125/large.jpg"');
     expect(body).not.toContain('og:image:width');
   });
 
   it('falls back to thumbnail when content-length header is missing', async () => {
     const response = await app.inject({ method: 'GET', url: '/view/137', headers: { 'user-agent': TELEGRAM_UA } });
     expect(response.statusCode).toBe(200);
-    expect(response.body).toContain('t.furaffinity.net/137@400-thumb.jpg');
-    expect(response.body).not.toContain('d.furaffinity.net/art/testartist/137/test.jpg');
+    expect(response.body).toContain('og:image" content="https://t.furaffinity.net/137@400-thumb.jpg"');
+    expect(response.body).not.toContain('og:image" content="https://d.furaffinity.net/art/testartist/137/test.jpg"');
   });
 
   it('uses video/mp4 for GIF on Telegram', async () => {
@@ -301,6 +307,59 @@ describe('telegram image embeds', () => {
     expect(body).toContain('og:video');
     expect(body).toContain('video/mp4');
     expect(body).not.toContain('og:image');
+  });
+});
+
+describe('telegram instant view', () => {
+  it('renders an article body with title, author and image for images', async () => {
+    const response = await app.inject({ method: 'GET', url: '/view/123', headers: { 'user-agent': TELEGRAM_UA } });
+    expect(response.statusCode).toBe(200);
+    const body = response.body;
+    expect(body).toContain('<body>');
+    expect(body).toContain('<article>');
+    expect(body).toContain('<h1>Test Image</h1>');
+    expect(body).toContain('rel="author"');
+    expect(body).toContain('<figure><img src="https://d.furaffinity.net/art/testartist/123/test.jpg"');
+  });
+
+  it('does not emit a body for non-telegram bots', async () => {
+    const response = await app.inject({ method: 'GET', url: '/view/123', headers: { 'user-agent': DISCORD_UA } });
+    expect(response.body).not.toContain('<body>');
+  });
+
+  it('renders the story text as paragraphs for stories', async () => {
+    const response = await app.inject({ method: 'GET', url: '/view/126', headers: { 'user-agent': TELEGRAM_UA } });
+    expect(response.statusCode).toBe(200);
+    const body = response.body;
+    expect(body).toContain('<article>');
+    expect(body).toContain('<h1>Test Story</h1>');
+    expect(body).toContain('Once upon a time');
+  });
+
+  it('renders an audio element for music', async () => {
+    const response = await app.inject({ method: 'GET', url: '/view/127', headers: { 'user-agent': TELEGRAM_UA } });
+    expect(response.statusCode).toBe(200);
+    const body = response.body;
+    expect(body).toContain('<article>');
+    expect(body).toContain('<audio src="https://d.furaffinity.net/art/testartist/127/song.mp3"');
+  });
+
+  it('renders the full rich description (not the truncated og snippet)', async () => {
+    const response = await app.inject({ method: 'GET', url: '/view/142', headers: { 'user-agent': TELEGRAM_UA } });
+    expect(response.statusCode).toBe(200);
+    const body = response.body;
+    const article = body.slice(body.indexOf('<article>'));
+    // Full text from .submission-description-text, not the truncated og:description snippet
+    expect(article).toContain('Full description with a');
+    expect(article).toContain('Second line kept.');
+    expect(article).not.toContain('A truncated snippet');
+    // Avatar icon link becomes an @username text link; external redirect is unwrapped
+    expect(article).toContain('<a href="https://www.furaffinity.net/user/friend">@friend</a>');
+    expect(article).toContain('href="https://example.com/art"');
+    expect(article).toContain('<b>link</b>');
+    // Styling and avatar images stripped
+    expect(body).not.toContain('color:red');
+    expect(body).not.toContain('a.furaffinity.net/x/friend.gif');
   });
 });
 


### PR DESCRIPTION
## What

Serves Telegram a full HTML `<article>` body alongside the existing OpenGraph tags, so Instant View templates can render a rich in-app preview instead of the app only redirecting mobile users to FurAffinity.

## Why

Telegram Instant View works by running an author-defined template (XPath) against the page's real body — meta tags alone aren't enough. Our Telegram responses were `<head>`-only, so there was nothing for a template to extract.

## Changes

- **Full description.** Parse the complete submission description from `.submission-description-text` and sanitize it to a safe subset: avatar-icon links become `@username` text links, FA's `/externalurl/?q=` redirects are decoded to the real destination, relative links are absolutized, and colours/styling/`<img>` avatars are stripped. Previously we only used FA's **truncated** `og:description`.
- **`descriptionHtml`** added to the submission info types; flows through the client automatically.
- **`<article>` body** for image / story / music Telegram embeds: title, author byline, media (image/video/thumbnail), story excerpt (`<blockquote>`) or audio, the rich description, and a stats footer.
- **`escapeHtml`** moved to a shared `src/html.ts` (used by both the parser and the embed builders).

Discord/other-bot embeds and the human redirect are unchanged. The card's `og:description` still uses FA's snippet — only the IV body carries the full text.

## Testing

- `pnpm test` — 52 pass, including a new fixture/test covering rich-description extraction (avatar→@username, external-redirect unwrapping, style stripping).
- Verified end-to-end through a Cloudflare tunnel against the IV editor; the template renders correctly.

## Notes / follow-ups

- Automatic IV activation on plainly-pasted links still depends on Telegram's template-approval path (long broken) — this PR delivers the body markup and validates it via `t.me/iv?...&rhash=`, not auto-activation.
- Stories currently expose only a ~400-char excerpt (the client fetches just the first 2KB of the `.txt`); full story text in IV would be a separate change.